### PR TITLE
Use environment flag for mock data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ REACT_APP_API_URL=http://localhost:8000
 REACT_APP_API_VERSION=v1
 
 # Feature Flags
+# Set to 'true' to enable mock data instead of real API calls
 REACT_APP_USE_MOCKS=false
 
 # OAuth Configuration

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -27,7 +27,7 @@ export const API = {
 /** Feature flags */
 export const FEATURES = {
   /** Whether to use mock data instead of real API calls */
-  USE_MOCKS: true,
+  USE_MOCKS: process.env.REACT_APP_USE_MOCKS === 'true',
   
   /** Development mode flag */
   IS_DEV: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
## Summary
- use `process.env.REACT_APP_USE_MOCKS` to control mock data mode
- document how to enable API mocks in `.env.example`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*